### PR TITLE
Clones States - Post CSM Summit Roundup (2016-10-10)

### DIFF
--- a/Amarr - Alpha Skills.xml
+++ b/Amarr - Alpha Skills.xml
@@ -7,6 +7,9 @@
   <entry skillID="33078" skill="Armor Layering" level="1" priority="3" type="Planned">
     <notes>Armor Layering</notes>
   </entry>
+  <entry skillID="24242" skill="Infomorph Psychology" level="1" priority="3" type="Planned">
+    <notes>Infomorph Psychology</notes>
+  </entry>
   <entry skillID="3394" skill="Hull Upgrades" level="3" priority="3" type="Prerequisite">
     <notes>EM Armor Compensation, Explosive Armor Compensation, Kinetic Armor Compensation, Thermal Armor Compensation</notes>
   </entry>
@@ -125,9 +128,6 @@
     <notes>Electronic Warfare</notes>
   </entry>
   <entry skillID="3427" skill="Electronic Warfare" level="3" priority="3" type="Planned">
-    <notes>Electronic Warfare</notes>
-  </entry>
-  <entry skillID="3427" skill="Electronic Warfare" level="4" priority="3" type="Planned">
     <notes>Electronic Warfare</notes>
   </entry>
   <entry skillID="3435" skill="Propulsion Jamming" level="2" priority="3" type="Planned">
@@ -540,6 +540,12 @@
   </entry>
   <entry skillID="3429" skill="Target Management" level="4" priority="3" type="Planned">
     <notes>Target Management</notes>
+  </entry>
+  <entry skillID="25544" skill="Gas Cloud Harvesting" level="1" priority="3" type="Planned">
+    <notes>Gas Cloud Harvesting</notes>
+  </entry>
+  <entry skillID="25544" skill="Gas Cloud Harvesting" level="2" priority="3" type="Planned">
+    <notes>Gas Cloud Harvesting</notes>
   </entry>
   <entry skillID="3446" skill="Broker Relations" level="1" priority="3" type="Planned">
     <notes>Broker Relations</notes>

--- a/Caldari - Alpha Skills.xml
+++ b/Caldari - Alpha Skills.xml
@@ -7,6 +7,9 @@
   <entry skillID="33078" skill="Armor Layering" level="1" priority="3" type="Planned">
     <notes>Armor Layering</notes>
   </entry>
+  <entry skillID="24242" skill="Infomorph Psychology" level="1" priority="3" type="Planned">
+    <notes>Infomorph Psychology</notes>
+  </entry>
   <entry skillID="3394" skill="Hull Upgrades" level="3" priority="3" type="Prerequisite">
     <notes>EM Armor Compensation, Explosive Armor Compensation, Kinetic Armor Compensation, Thermal Armor Compensation</notes>
   </entry>
@@ -46,6 +49,12 @@
   <entry skillID="3436" skill="Drones" level="3" priority="3" type="Prerequisite">
     <notes>Drone Interfacing, Drone Navigation, Light Drone Operation, Medium Drone Operation, Repair Drone Operation</notes>
   </entry>
+  <entry skillID="3436" skill="Drones" level="4" priority="3" type="Prerequisite">
+    <notes>Drone Interfacing, Drone Navigation, Light Drone Operation, Medium Drone Operation, Repair Drone Operation</notes>
+  </entry>
+  <entry skillID="3436" skill="Drones" level="5" priority="3" type="Prerequisite">
+    <notes>Drone Interfacing, Drone Navigation, Light Drone Operation, Medium Drone Operation, Repair Drone Operation</notes>
+  </entry>
   <entry skillID="24241" skill="Light Drone Operation" level="1" priority="3" type="Planned">
     <notes>Light Drone Operation</notes>
   </entry>
@@ -53,9 +62,6 @@
     <notes>Electronic Warfare</notes>
   </entry>
   <entry skillID="3427" skill="Electronic Warfare" level="3" priority="3" type="Planned">
-    <notes>Electronic Warfare</notes>
-  </entry>
-  <entry skillID="3427" skill="Electronic Warfare" level="4" priority="3" type="Planned">
     <notes>Electronic Warfare</notes>
   </entry>
   <entry skillID="3435" skill="Propulsion Jamming" level="2" priority="3" type="Planned">
@@ -588,6 +594,12 @@
   </entry>
   <entry skillID="3429" skill="Target Management" level="4" priority="3" type="Planned">
     <notes>Target Management</notes>
+  </entry>
+  <entry skillID="25544" skill="Gas Cloud Harvesting" level="1" priority="3" type="Planned">
+    <notes>Gas Cloud Harvesting</notes>
+  </entry>
+  <entry skillID="25544" skill="Gas Cloud Harvesting" level="2" priority="3" type="Planned">
+    <notes>Gas Cloud Harvesting</notes>
   </entry>
   <entry skillID="3446" skill="Broker Relations" level="1" priority="3" type="Planned">
     <notes>Broker Relations</notes>

--- a/Gallente - Alpha Skills.xml
+++ b/Gallente - Alpha Skills.xml
@@ -7,6 +7,9 @@
   <entry skillID="33078" skill="Armor Layering" level="1" priority="3" type="Planned">
     <notes>Armor Layering</notes>
   </entry>
+  <entry skillID="24242" skill="Infomorph Psychology" level="1" priority="3" type="Planned">
+    <notes>Infomorph Psychology</notes>
+  </entry>
   <entry skillID="3394" skill="Hull Upgrades" level="3" priority="3" type="Prerequisite">
     <notes>EM Armor Compensation, Explosive Armor Compensation, Kinetic Armor Compensation, Thermal Armor Compensation</notes>
   </entry>
@@ -125,9 +128,6 @@
     <notes>Electronic Warfare</notes>
   </entry>
   <entry skillID="3427" skill="Electronic Warfare" level="3" priority="3" type="Planned">
-    <notes>Electronic Warfare</notes>
-  </entry>
-  <entry skillID="3427" skill="Electronic Warfare" level="4" priority="3" type="Planned">
     <notes>Electronic Warfare</notes>
   </entry>
   <entry skillID="3435" skill="Propulsion Jamming" level="2" priority="3" type="Planned">
@@ -549,6 +549,12 @@
   </entry>
   <entry skillID="3429" skill="Target Management" level="4" priority="3" type="Planned">
     <notes>Target Management</notes>
+  </entry>
+  <entry skillID="25544" skill="Gas Cloud Harvesting" level="1" priority="3" type="Planned">
+    <notes>Gas Cloud Harvesting</notes>
+  </entry>
+  <entry skillID="25544" skill="Gas Cloud Harvesting" level="2" priority="3" type="Planned">
+    <notes>Gas Cloud Harvesting</notes>
   </entry>
   <entry skillID="3446" skill="Broker Relations" level="1" priority="3" type="Planned">
     <notes>Broker Relations</notes>

--- a/Minmatar - Alpha Skills.xml
+++ b/Minmatar - Alpha Skills.xml
@@ -7,6 +7,9 @@
   <entry skillID="33078" skill="Armor Layering" level="1" priority="3" type="Planned">
     <notes>Armor Layering</notes>
   </entry>
+  <entry skillID="24242" skill="Infomorph Psychology" level="1" priority="3" type="Planned">
+    <notes>Infomorph Psychology</notes>
+  </entry>
   <entry skillID="3394" skill="Hull Upgrades" level="3" priority="3" type="Prerequisite">
     <notes>EM Armor Compensation, Explosive Armor Compensation, Kinetic Armor Compensation, Thermal Armor Compensation</notes>
   </entry>
@@ -46,6 +49,12 @@
   <entry skillID="3436" skill="Drones" level="3" priority="3" type="Prerequisite">
     <notes>Drone Interfacing, Drone Navigation, Light Drone Operation, Medium Drone Operation, Repair Drone Operation</notes>
   </entry>
+  <entry skillID="3436" skill="Drones" level="4" priority="3" type="Prerequisite">
+    <notes>Drone Interfacing, Drone Navigation, Light Drone Operation, Medium Drone Operation, Repair Drone Operation</notes>
+  </entry>
+  <entry skillID="3436" skill="Drones" level="5" priority="3" type="Prerequisite">
+    <notes>Drone Interfacing, Drone Navigation, Light Drone Operation, Medium Drone Operation, Repair Drone Operation</notes>
+  </entry>
   <entry skillID="24241" skill="Light Drone Operation" level="1" priority="3" type="Planned">
     <notes>Light Drone Operation</notes>
   </entry>
@@ -53,9 +62,6 @@
     <notes>Electronic Warfare</notes>
   </entry>
   <entry skillID="3427" skill="Electronic Warfare" level="3" priority="3" type="Planned">
-    <notes>Electronic Warfare</notes>
-  </entry>
-  <entry skillID="3427" skill="Electronic Warfare" level="4" priority="3" type="Planned">
     <notes>Electronic Warfare</notes>
   </entry>
   <entry skillID="3435" skill="Propulsion Jamming" level="2" priority="3" type="Planned">
@@ -600,6 +606,12 @@
   </entry>
   <entry skillID="3429" skill="Target Management" level="4" priority="3" type="Planned">
     <notes>Target Management</notes>
+  </entry>
+  <entry skillID="25544" skill="Gas Cloud Harvesting" level="1" priority="3" type="Planned">
+    <notes>Gas Cloud Harvesting</notes>
+  </entry>
+  <entry skillID="25544" skill="Gas Cloud Harvesting" level="2" priority="3" type="Planned">
+    <notes>Gas Cloud Harvesting</notes>
   </entry>
   <entry skillID="3446" skill="Broker Relations" level="1" priority="3" type="Planned">
     <notes>Broker Relations</notes>

--- a/Minmatar - Alpha Skills.xml
+++ b/Minmatar - Alpha Skills.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <plan xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Alpha Skills" owner="fb1ec094-94e6-450e-a38f-1696b25669aa" revision="4658">
   <sorting criteria="None" order="None" groupByPriority="false" />
   <entry skillID="3392" skill="Mechanics" level="3" priority="3" type="Prerequisite">
@@ -541,40 +541,40 @@
   <entry skillID="3895" skill="Security Connections" level="2" priority="3" type="Planned">
     <notes>Security Connections</notes>
   </entry>
-  <entry skillID="3330" skill="Caldari Frigate" level="1" priority="3" type="Prerequisite">
+  <entry skillID="3329" skill="Minmatar Frigate" level="1" priority="3" type="Prerequisite">
     <notes />
   </entry>
-  <entry skillID="3330" skill="Caldari Frigate" level="2" priority="3" type="Prerequisite">
+  <entry skillID="3329" skill="Minmatar Frigate" level="2" priority="3" type="Prerequisite">
     <notes />
   </entry>
-  <entry skillID="3330" skill="Caldari Frigate" level="3" priority="3" type="Prerequisite">
+  <entry skillID="3329" skill="Minmatar Frigate" level="3" priority="3" type="Prerequisite">
     <notes />
   </entry>
-  <entry skillID="33092" skill="Caldari Destroyer" level="1" priority="3" type="Prerequisite">
+  <entry skillID="33094" skill="Minmatar Destroyer" level="1" priority="3" type="Prerequisite">
     <notes>Caldari Cruiser</notes>
   </entry>
-  <entry skillID="33092" skill="Caldari Destroyer" level="2" priority="3" type="Prerequisite">
+  <entry skillID="33094" skill="Minmatar Destroyer" level="2" priority="3" type="Prerequisite">
     <notes>Caldari Cruiser</notes>
   </entry>
-  <entry skillID="33092" skill="Caldari Destroyer" level="3" priority="3" type="Prerequisite">
+  <entry skillID="33094" skill="Minmatar Destroyer" level="3" priority="3" type="Prerequisite">
     <notes>Caldari Cruiser</notes>
   </entry>
-  <entry skillID="3334" skill="Caldari Cruiser" level="1" priority="3" type="Planned">
+  <entry skillID="3333" skill="Minmatar Cruiser" level="1" priority="3" type="Planned">
     <notes>Caldari Cruiser</notes>
   </entry>
-  <entry skillID="3334" skill="Caldari Cruiser" level="2" priority="3" type="Planned">
+  <entry skillID="3333" skill="Minmatar Cruiser" level="2" priority="3" type="Planned">
     <notes>Caldari Cruiser</notes>
   </entry>
-  <entry skillID="3334" skill="Caldari Cruiser" level="3" priority="3" type="Planned">
+  <entry skillID="3333" skill="Minmatar Cruiser" level="3" priority="3" type="Planned">
     <notes>Caldari Cruiser</notes>
   </entry>
-  <entry skillID="3334" skill="Caldari Cruiser" level="4" priority="3" type="Planned">
+  <entry skillID="3333" skill="Minmatar Cruiser" level="4" priority="3" type="Planned">
     <notes>Caldari Cruiser</notes>
   </entry>
-  <entry skillID="33092" skill="Caldari Destroyer" level="4" priority="3" type="Planned">
+  <entry skillID="33094" skill="Minmatar Destroyer" level="4" priority="3" type="Planned">
     <notes>Caldari Destroyer</notes>
   </entry>
-  <entry skillID="3330" skill="Caldari Frigate" level="4" priority="3" type="Planned">
+  <entry skillID="3329" skill="Minmatar Frigate" level="4" priority="3" type="Planned">
     <notes>Caldari Frigate</notes>
   </entry>
   <entry skillID="32918" skill="Mining Frigate" level="2" priority="3" type="Planned">


### PR DESCRIPTION
- Add Infomorph Psychology I
- Raise Drones to V for Caldari and Minmatar (from III)
- Add Gas Harvesting II to all factions
- Lower Electronic Warfare to III (from IV)

https://community.eveonline.com/news/dev-blogs/clone-states-post-csm-summit-roundup/