### PR TITLE
Remove Ice Harvesting, Add Reactions

### DIFF
--- a/Alpha Skills - All.xml
+++ b/Alpha Skills - All.xml
@@ -290,8 +290,6 @@
   <entry skillID="3387" skill="Mass Production" level="2" priority="3" type="Planned" />
   <entry skillID="3387" skill="Mass Production" level="3" priority="3" type="Planned" />
   <entry skillID="3386" skill="Mining" level="4" priority="3" type="Planned" />
-  <entry skillID="16281" skill="Ice Harvesting" level="1" priority="3" type="Planned" />
-  <entry skillID="16281" skill="Ice Harvesting" level="2" priority="3" type="Planned" />
   <entry skillID="22578" skill="Mining Upgrades" level="1" priority="3" type="Planned" />
   <entry skillID="22578" skill="Mining Upgrades" level="2" priority="3" type="Planned" />
   <entry skillID="22578" skill="Mining Upgrades" level="3" priority="3" type="Planned" />
@@ -474,4 +472,5 @@
   <entry skillID="3446" skill="Broker Relations" level="2" priority="3" type="Planned" />
   <entry skillID="16598" skill="Marketing" level="1" priority="3" type="Planned" />
   <entry skillID="16598" skill="Marketing" level="2" priority="3" type="Planned" />
+  <entry skillID="45746" skill="Reactions" level="1" priority="3" type="Planned" />
 </plan>

--- a/by Group/Alpha Skills - Resource Processing.xml
+++ b/by Group/Alpha Skills - Resource Processing.xml
@@ -2,8 +2,6 @@
 <plan xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4658">
   <sorting criteria="None" order="None" groupByPriority="false" />
   <entry skillID="3386" skill="Mining" level="4" priority="3" type="Planned" />
-  <entry skillID="16281" skill="Ice Harvesting" level="1" priority="3" type="Planned" />
-  <entry skillID="16281" skill="Ice Harvesting" level="2" priority="3" type="Planned" />
   <entry skillID="22578" skill="Mining Upgrades" level="1" priority="3" type="Planned" />
   <entry skillID="22578" skill="Mining Upgrades" level="2" priority="3" type="Planned" />
   <entry skillID="22578" skill="Mining Upgrades" level="3" priority="3" type="Planned" />
@@ -13,4 +11,5 @@
   <entry skillID="3385" skill="Reprocessing" level="3" priority="3" type="Planned" />
   <entry skillID="25544" skill="Gas Cloud Harvesting" level="1" priority="3" type="Planned" />
   <entry skillID="25544" skill="Gas Cloud Harvesting" level="2" priority="3" type="Planned" />
+  <entry skillID="45746" skill="Reactions" level="1" priority="3" type="Planned" />
 </plan>


### PR DESCRIPTION
Remove Ice Harvesting
- [Clone States - The next steps](https://community.eveonline.com/news/dev-blogs/clone-states-the-next-steps/) dev blog lists Ice Harvesting up to level 2 as being available to Alpha Clones, however it is not available in game, at least not for my Minmatar clone.

Add Reactions Ice
- Reactions I appears to be available to Alpha Clones